### PR TITLE
Fix MySQLi connection using SSL

### DIFF
--- a/lib/Horde/Db/Adapter/Mysqli.php
+++ b/lib/Horde/Db/Adapter/Mysqli.php
@@ -128,7 +128,7 @@ class Horde_Db_Adapter_Mysqli extends Horde_Db_Adapter_Base
             );
             $mysqli->real_connect(
                 $config['host'], $config['username'], $config['password'],
-                $config['dbname'], $config['port'], $config['socket']);
+                $config['dbname'], $config['port'], $config['socket'], MYSQLI_CLIENT_SSL);
         } else {
             $mysqli = new mysqli(
                 $config['host'], $config['username'], $config['password'],


### PR DESCRIPTION
With PHP 5.6 `real_connect()` will not attempt a SSL connection without the `MYSQLI_CLIENT_SSL` flag.