### PR TITLE
postgresql 12 compatibility, pg_attrdef.adsrc dropped

### DIFF
--- a/lib/Horde/Db/Adapter/Postgresql/Schema.php
+++ b/lib/Horde/Db/Adapter/Postgresql/Schema.php
@@ -1061,14 +1061,14 @@ class Horde_Db_Adapter_Postgresql_Schema extends Horde_Db_Adapter_Base_Schema
             if ($sequence) {
                 $quotedSequence = $this->quoteSequenceName($sequence);
                 $quotedTable = $this->quoteTableName($table);
-                $quotedPk = $this->quoteColumnName($pk);
-
-                $sql = sprintf('SELECT setval(%s, (SELECT COALESCE(MAX(%s) + (SELECT increment_by FROM %s), (SELECT min_value FROM %s)) FROM %s), false)',
+								$quotedPk = $this->quoteColumnName($pk);
+								$sql = sprintf('SELECT setval(%s, (SELECT COALESCE(MAX(%s) + (SELECT increment_by FROM pg_sequences where schemaname= ANY (CURRENT_SCHEMAS(false)) and sequencename=%s), (SELECT min_value FROM pg_sequences where schemaname= ANY (CURRENT_SCHEMAS(false)) and sequencename=%s)) FROM %s), false)',
                                $quotedSequence,
                                $quotedPk,
-                               $sequence,
-                               $sequence,
+                               $quotedSequence,
+                               $quotedSequence,
                                $quotedTable);
+
                 $this->selectValue($sql, 'Reset sequence');
             } else {
                 if ($this->_logger) {


### PR DESCRIPTION
Since pg_attrdef.adsrc has been finally dropped, current code is not compatible anymore with PostgresQL 12.

pg_get_serial_sequence() and pg_get_expr were supported from version prior to 8.2.
One of the queries has been completely rewritten to use information_schema that is part of SQL standard.

My only concern is that original query returned default values for sequences with the schema specifier prefixed, while new incarnation return it without schema

eg.

nextval('horde_alarms_id_seq'::regclass)

vs.

nextval('public.horde_alarms_id_seq'::regclass)

Behavior could be changed emptying schema_path but this shouldn't be a concern because the sequence should already be there and unless Horde somewhere change search_path or create sequences with the same name in 2 different schema, postgresql will refer to the correct sequence.

I'd like to tank Tom Lane (tgl@openvistas.net) and Laurenz Albe (laurenz.albe@cybertec.at) for their help.

