### PR TITLE
 Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Db/Adapter/Base/Column.php
+++ b/lib/Horde/Db/Adapter/Base/Column.php
@@ -303,7 +303,7 @@ class Horde_Db_Adapter_Base_Column
      */
     protected function _extractLimit($sqlType)
     {
-        if (preg_match("/\((.*)\)/", $sqlType, $matches)) {
+        if (preg_match("/\((.*)\)/", is_null($sqlType) ? "" : $sqlType, $matches)) {
             return (int)$matches[1];
         }
         return null;
@@ -315,7 +315,7 @@ class Horde_Db_Adapter_Base_Column
      */
     protected function _extractPrecision($sqlType)
     {
-        if (preg_match("/^(numeric|decimal|number)\((\d+)(,\d+)?\)/i", $sqlType, $matches)) {
+        if (preg_match("/^(numeric|decimal|number)\((\d+)(,\d+)?\)/i", is_null($sqlType) ? "" : $sqlType, $matches)) {
             return (int)$matches[2];
         }
         return null;
@@ -328,10 +328,10 @@ class Horde_Db_Adapter_Base_Column
     protected function _extractScale($sqlType)
     {
         switch (true) {
-            case preg_match("/^(numeric|decimal|number)\((\d+)\)/i", $sqlType):
+	case preg_match("/^(numeric|decimal|number)\((\d+)\)/i", is_null($sqlType) ? "" : $sqlType):
                 return 0;
             case preg_match("/^(numeric|decimal|number)\((\d+)(,(\d+))\)/i",
-                            $sqlType, $match):
+                            is_null($sqlType) ? "" : $sqlType, $match):
                 return (int)$match[4];
         }
     }
@@ -342,7 +342,7 @@ class Horde_Db_Adapter_Base_Column
      */
     protected function _extractUnsigned($sqlType)
     {
-        return (boolean)preg_match('/^int.*unsigned/i', $sqlType);
+        return (boolean)preg_match('/^int.*unsigned/i', is_null($sqlType) ? "" : $sqlType);
     }
 
     /**
@@ -350,37 +350,37 @@ class Horde_Db_Adapter_Base_Column
     protected function _setSimplifiedType()
     {
         switch (true) {
-        case preg_match('/int/i', $this->_sqlType):
+	case preg_match('/int/i', is_null($this->_sqlType) ? "" : $this->_sqlType):
             $this->_type = 'integer';
             return;
-        case preg_match('/float|double/i', $this->_sqlType):
+	case preg_match('/float|double/i', is_null($this->_sqlType) ? "" : $this->_sqlType):
             $this->_type = 'float';
             return;
-        case preg_match('/decimal|numeric|number/i', $this->_sqlType):
+        case preg_match('/decimal|numeric|number/i', is_null($this->_sqlType) ? "" : $this->_sqlType):
             $this->_type = $this->_scale == 0 ? 'integer' : 'decimal';
             return;
-        case preg_match('/datetime/i', $this->_sqlType):
+        case preg_match('/datetime/i', is_null($this->_sqlType) ? "" : $this->_sqlType):
             $this->_type = 'datetime';
             return;
-        case preg_match('/timestamp/i', $this->_sqlType):
+        case preg_match('/timestamp/i', is_null($this->_sqlType) ? "" : $this->_sqlType):
             $this->_type = 'timestamp';
             return;
-        case preg_match('/time/i', $this->_sqlType):
+        case preg_match('/time/i', is_null($this->_sqlType) ? "" : $this->_sqlType):
             $this->_type = 'time';
             return;
-        case preg_match('/date/i', $this->_sqlType):
+        case preg_match('/date/i', is_null($this->_sqlType) ? "" : $this->_sqlType):
             $this->_type = 'date';
             return;
-        case preg_match('/clob|text/i', $this->_sqlType):
+        case preg_match('/clob|text/i', is_null($this->_sqlType) ? "" : $this->_sqlType):
             $this->_type = 'text';
             return;
-        case preg_match('/blob|binary/i', $this->_sqlType):
+        case preg_match('/blob|binary/i', is_null($this->_sqlType) ? "" : $this->_sqlType):
             $this->_type = 'binary';
             return;
-        case preg_match('/char|string/i', $this->_sqlType):
+        case preg_match('/char|string/i', is_null($this->_sqlType) ? "" : $this->_sqlType):
             $this->_type = 'string';
             return;
-        case preg_match('/boolean/i', $this->_sqlType):
+        case preg_match('/boolean/i', is_null($this->_sqlType) ? "" : $this->_sqlType):
             $this->_type = 'boolean';
             return;
         }

--- a/lib/Horde/Db/Adapter/Base/Result.php
+++ b/lib/Horde/Db/Adapter/Base/Result.php
@@ -108,7 +108,7 @@ abstract class Horde_Db_Adapter_Base_Result implements Iterator
     /**
      * Implementation of the rewind() method for iterator.
      */
-    public function rewind()
+    public function rewind(): void
     {
         if ($this->_result) {
             unset($this->_result);
@@ -128,7 +128,7 @@ abstract class Horde_Db_Adapter_Base_Result implements Iterator
      *
      * @return array  The current row, or null if no rows.
      */
-    public function current()
+    public function current(): array
     {
         if (is_null($this->_result)) {
             $this->rewind();
@@ -141,7 +141,7 @@ abstract class Horde_Db_Adapter_Base_Result implements Iterator
      *
      * @return mixed  The current row number (starts at 0), or null if no rows.
      */
-    public function key()
+    public function key(): mixed
     {
         if (is_null($this->_result)) {
             $this->rewind();
@@ -152,10 +152,10 @@ abstract class Horde_Db_Adapter_Base_Result implements Iterator
     /**
      * Implementation of the next() method for Iterator.
      *
-     * @return array|null  The next row in the resultset or null if there are
+     * @return void        The next row in the resultset or null if there are
      *                     no more results.
      */
-    public function next()
+    public function next(): void
     {
         if (is_null($this->_result)) {
             $this->rewind();
@@ -177,8 +177,6 @@ abstract class Horde_Db_Adapter_Base_Result implements Iterator
                 $this->_current = $row;
             }
         }
-
-        return $this->_current;
     }
 
     /**
@@ -186,7 +184,7 @@ abstract class Horde_Db_Adapter_Base_Result implements Iterator
      *
      * @return boolean  Whether the iteration is valid.
      */
-    public function valid()
+    public function valid(): bool
     {
         if (is_null($this->_result)) {
             $this->rewind();

--- a/lib/Horde/Db/Adapter/Base/Table.php
+++ b/lib/Horde/Db/Adapter/Base/Table.php
@@ -153,7 +153,7 @@ class Horde_Db_Adapter_Base_Table implements ArrayAccess, IteratorAggregate
      * @param   int     $offset
      * @return  boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->_columns[$offset]);
     }
@@ -164,7 +164,7 @@ class Horde_Db_Adapter_Base_Table implements ArrayAccess, IteratorAggregate
      * @param   int     $offset
      * @return  object  {@link {@Horde_Db_Adapter_Base_ColumnDefinition}
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->getColumn($offset);
     }
@@ -175,7 +175,7 @@ class Horde_Db_Adapter_Base_Table implements ArrayAccess, IteratorAggregate
      * @param   int     $offset
      * @param   mixed   $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
     }
 
@@ -184,7 +184,7 @@ class Horde_Db_Adapter_Base_Table implements ArrayAccess, IteratorAggregate
      *
      * @param   int     $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
     }
 
@@ -193,7 +193,7 @@ class Horde_Db_Adapter_Base_Table implements ArrayAccess, IteratorAggregate
     # IteratorAggregate
     ##########################################################################*/
 
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_columns);
     }

--- a/lib/Horde/Db/Adapter/Base/TableDefinition.php
+++ b/lib/Horde/Db/Adapter/Base/TableDefinition.php
@@ -257,7 +257,7 @@ class Horde_Db_Adapter_Base_TableDefinition implements ArrayAccess, IteratorAggr
      * @param   int     $offset
      * @return  boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         foreach ($this->_columns as $column) {
             if ($column->getName() == $offset) return true;
@@ -271,7 +271,7 @@ class Horde_Db_Adapter_Base_TableDefinition implements ArrayAccess, IteratorAggr
      * @param   int     $offset
      * @return  object  {@link {@Horde_Db_Adapter_Base_ColumnDefinition}
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (!$this->offsetExists($offset)) {
             return null;
@@ -290,7 +290,7 @@ class Horde_Db_Adapter_Base_TableDefinition implements ArrayAccess, IteratorAggr
      * @param   int     $offset
      * @param   mixed   $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         foreach ($this->_columns as $key=>$column) {
             if ($column->getName() == $offset) {
@@ -304,7 +304,7 @@ class Horde_Db_Adapter_Base_TableDefinition implements ArrayAccess, IteratorAggr
      *
      * @param   int     $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         foreach ($this->_columns as $key=>$column) {
             if ($column->getName() == $offset) {
@@ -318,7 +318,7 @@ class Horde_Db_Adapter_Base_TableDefinition implements ArrayAccess, IteratorAggr
     # IteratorAggregate
     ##########################################################################*/
 
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_columns);
     }

--- a/lib/Horde/Db/Adapter/Mysql/Column.php
+++ b/lib/Horde/Db/Adapter/Mysql/Column.php
@@ -64,7 +64,7 @@ class Horde_Db_Adapter_Mysql_Column extends Horde_Db_Adapter_Base_Column
         if (strpos(Horde_String::lower($this->_sqlType), 'tinyint(1)') !== false) {
             $this->_type = 'boolean';
             return;
-        } elseif (preg_match('/enum/i', $this->_sqlType)) {
+        } elseif (preg_match('/enum/i', is_null($this->_sqlType) ? "" : $this->_sqlType)) {
             $this->_type = 'string';
             return;
         }

--- a/lib/Horde/Db/Adapter/Mysql/Schema.php
+++ b/lib/Horde/Db/Adapter/Mysql/Schema.php
@@ -576,8 +576,8 @@ class Horde_Db_Adapter_Mysql_Schema extends Horde_Db_Adapter_Base_Schema
      */
     public function _mysqlCharsetName($charset)
     {
-        $charset = preg_replace(array('/[^a-z0-9]/', '/iso8859(\d)/'),
-                                array('', 'latin$1'),
+        $charset = preg_replace(array('/[^a-z0-9]/', '/iso8859(\d)/', '/^utf8$/'),
+                                array('', 'latin$1', 'utf8mb4'),
                                 Horde_String::lower($charset));
         $validCharsets = $this->selectValues('SHOW CHARACTER SET');
         if (!in_array($charset, $validCharsets)) {

--- a/lib/Horde/Db/Adapter/Pdo/Sqlite.php
+++ b/lib/Horde/Db/Adapter/Pdo/Sqlite.php
@@ -100,7 +100,7 @@ class Horde_Db_Adapter_Pdo_Sqlite extends Horde_Db_Adapter_Pdo_Base
             return;
         }
 
-        parent::connect();
+        parent::class::connect();
 
         $this->_connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 
@@ -184,11 +184,11 @@ class Horde_Db_Adapter_Pdo_Sqlite extends Horde_Db_Adapter_Pdo_Base
     protected function _catchSchemaChanges($method, $args = array())
     {
         try {
-            return call_user_func_array(array($this, "parent::$method"), $args);
+            return call_user_func_array(array("Horde_Db_Adapter_Pdo_Base", "$method"), $args);
         } catch (Exception $e) {
             if (preg_match('/database schema has changed/i', $e->getMessage())) {
                 $this->reconnect();
-                return call_user_func_array(array($this, "parent::$method"), $args);
+                return call_user_func_array(array("Horde_Db_Adapter_Pdo_Base", "$method"), $args);
             } else {
                 throw $e;
             }

--- a/lib/Horde/Db/Adapter/Postgresql/Column.php
+++ b/lib/Horde/Db/Adapter/Postgresql/Column.php
@@ -64,50 +64,50 @@ class Horde_Db_Adapter_Postgresql_Column extends Horde_Db_Adapter_Base_Column
     protected function _setSimplifiedType()
     {
         switch (true) {
-        case preg_match('/^(?:real|double precision)$/', $this->_sqlType):
+        case preg_match('/^(?:real|double precision)$/', is_null($this->_sqlType) ? "" : $this->_sqlType):
             // Numeric and monetary types
             $this->_type = 'float';
             return;
-        case preg_match('/^money$/', $this->_sqlType):
+        case preg_match('/^money$/', is_null($this->_sqlType) ? "" : $this->_sqlType):
             // Monetary types
             $this->_type = 'decimal';
             return;
-        case preg_match('/^(?:character varying|bpchar)(?:\(\d+\))?$/', $this->_sqlType):
+        case preg_match('/^(?:character varying|bpchar)(?:\(\d+\))?$/', is_null($this->_sqlType) ? "" : $this->_sqlType):
             // Character types
             $this->_type = 'string';
             return;
-        case preg_match('/^bytea$/', $this->_sqlType):
+        case preg_match('/^bytea$/', is_null($this->_sqlType) ? "" : $this->_sqlType):
             // Binary data types
             $this->_type = 'binary';
             return;
-        case preg_match('/^timestamp with(?:out)? time zone$/', $this->_sqlType):
+        case preg_match('/^timestamp with(?:out)? time zone$/', is_null($this->_sqlType) ? "" : $this->_sqlType):
             // Date/time types
             $this->_type = 'datetime';
             return;
-        case preg_match('/^interval$/', $this->_sqlType):
+        case preg_match('/^interval$/', is_null($this->_sqlType) ? "" : $this->_sqlType):
             $this->_type = 'string';
             return;
-        case preg_match('/^(?:point|line|lseg|box|"?path"?|polygon|circle)$/', $this->_sqlType):
+        case preg_match('/^(?:point|line|lseg|box|"?path"?|polygon|circle)$/', is_null($this->_sqlType) ? "" : $this->_sqlType):
             // Geometric types
             $this->_type = 'string';
             return;
-        case preg_match('/^(?:cidr|inet|macaddr)$/', $this->_sqlType):
+        case preg_match('/^(?:cidr|inet|macaddr)$/', is_null($this->_sqlType) ? "" : $this->_sqlType):
             // Network address types
             $this->_type = 'string';
             return;
-        case preg_match('/^bit(?: varying)?(?:\(\d+\))?$/', $this->_sqlType):
+        case preg_match('/^bit(?: varying)?(?:\(\d+\))?$/', is_null($this->_sqlType) ? "" : $this->_sqlType):
             // Bit strings
             $this->_type = 'string';
             return;
-        case preg_match('/^xml$/', $this->_sqlType):
+        case preg_match('/^xml$/', is_null($this->_sqlType) ? "" : $this->_sqlType):
             // XML type
             $this->_type = 'string';
             return;
-        case preg_match('/^\D+\[\]$/', $this->_sqlType):
+        case preg_match('/^\D+\[\]$/', is_null($this->_sqlType) ? "" : $this->_sqlType):
             // Arrays
             $this->_type = 'string';
             return;
-        case preg_match('/^oid$/', $this->_sqlType):
+        case preg_match('/^oid$/', is_null($this->_sqlType) ? "" : $this->_sqlType):
             // Object identifier types
             $this->_type = 'integer';
             return;
@@ -123,45 +123,45 @@ class Horde_Db_Adapter_Postgresql_Column extends Horde_Db_Adapter_Base_Column
     protected function _extractValueFromDefault($default)
     {
         switch (true) {
-        case preg_match('/\A-?\d+(\.\d*)?\z/', $default):
+        case preg_match('/\A-?\d+(\.\d*)?\z/', is_null($default) ? "" : $default):
             // Numeric types
             return $default;
-        case preg_match('/\A\'(.*)\'::(?:character varying|bpchar|text)\z/m', $default, $matches):
+        case preg_match('/\A\'(.*)\'::(?:character varying|bpchar|text)\z/m', is_null($default) ? "" : $default, $matches):
             // Character types
             return $matches[1];
-        case preg_match('/\AE\'(.*)\'::(?:character varying|bpchar|text)\z/m', $default, $matches):
+        case preg_match('/\AE\'(.*)\'::(?:character varying|bpchar|text)\z/m', is_null($default) ? "" : $default, $matches):
             // Character types (8.1 formatting)
             /*@TODO fix preg callback*/
             return preg_replace('/\\(\d\d\d)/', '$1.oct.chr', $matches[1]);
-        case preg_match('/\A\'(.*)\'::bytea\z/m', $default, $matches):
+        case preg_match('/\A\'(.*)\'::bytea\z/m', is_null($default) ? "" : $default, $matches):
             // Binary data types
             return $matches[1];
-        case preg_match('/\A\'(.+)\'::(?:time(?:stamp)? with(?:out)? time zone|date)\z/', $default, $matches):
+        case preg_match('/\A\'(.+)\'::(?:time(?:stamp)? with(?:out)? time zone|date)\z/', is_null($default) ? "" : $default, $matches):
             // Date/time types
             return $matches[1];
-        case preg_match('/\A\'(.*)\'::interval\z/', $default, $matches):
+        case preg_match('/\A\'(.*)\'::interval\z/', is_null($default) ? "" : $default, $matches):
             return $matches[1];
         case $default == 'true':
             // Boolean type
             return true;
         case $default == 'false':
             return false;
-        case preg_match('/\A\'(.*)\'::(?:point|line|lseg|box|"?path"?|polygon|circle)\z/', $default, $matches):
+        case preg_match('/\A\'(.*)\'::(?:point|line|lseg|box|"?path"?|polygon|circle)\z/', is_null($default) ? "" : $default, $matches):
             // Geometric types
             return $matches[1];
-        case preg_match('/\A\'(.*)\'::(?:cidr|inet|macaddr)\z/', $default, $matches):
+        case preg_match('/\A\'(.*)\'::(?:cidr|inet|macaddr)\z/', is_null($default) ? "" : $default, $matches):
             // Network address types
             return $matches[1];
-        case preg_match('/\AB\'(.*)\'::"?bit(?: varying)?"?\z/', $default, $matches):
+        case preg_match('/\AB\'(.*)\'::"?bit(?: varying)?"?\z/', is_null($default) ? "" : $default, $matches):
             // Bit string types
             return $matches[1];
-        case preg_match('/\A\'(.*)\'::xml\z/m', $default, $matches):
+        case preg_match('/\A\'(.*)\'::xml\z/m', is_null($default) ? "" : $default, $matches):
             // XML type
             return $matches[1];
-        case preg_match('/\A\'(.*)\'::"?\D+"?\[\]\z/', $default, $matches):
+        case preg_match('/\A\'(.*)\'::"?\D+"?\[\]\z/', is_null($default) ? "" : $default, $matches):
             // Arrays
             return $matches[1];
-        case preg_match('/\A-?\d+\z/', $default, $matches):
+        case preg_match('/\A-?\d+\z/', is_null($default) ? "" : $default, $matches):
             // Object identifier types
             return $matches[1];
         default:
@@ -185,7 +185,7 @@ class Horde_Db_Adapter_Postgresql_Column extends Horde_Db_Adapter_Base_Column
             return $string;
         }
 
-        return preg_replace_callback("/(?:\\\'|\\\\\\\\|\\\\\d{3})/", array($this, 'binaryToStringCallback'), $value);
+        return preg_replace_callback("/(?:\\\'|\\\\\\\\|\\\\\d{3})/", array($this, 'binaryToStringCallback'), is_null($value) ? "" : $value);
     }
 
     /**
@@ -213,10 +213,10 @@ class Horde_Db_Adapter_Postgresql_Column extends Horde_Db_Adapter_Base_Column
      */
     protected function _extractLimit($sqlType)
     {
-        if (preg_match('/^bigint/i', $sqlType)) {
+        if (preg_match('/^bigint/i', is_null($sqlType) ? "" : $sqlType)) {
             return 8;
         }
-        if (preg_match('/^smallint/i', $sqlType)) {
+        if (preg_match('/^smallint/i', is_null($sqlType) ? "" : $sqlType)) {
             return 2;
         }
         return parent::_extractLimit($sqlType);
@@ -228,7 +228,7 @@ class Horde_Db_Adapter_Postgresql_Column extends Horde_Db_Adapter_Base_Column
      */
     protected function _extractPrecision($sqlType)
     {
-        if (preg_match('/^money/', $sqlType)) {
+        if (preg_match('/^money/', is_null($sqlType) ? "" : $sqlType)) {
             return self::$moneyPrecision;
         }
         return parent::_extractPrecision($sqlType);
@@ -240,7 +240,7 @@ class Horde_Db_Adapter_Postgresql_Column extends Horde_Db_Adapter_Base_Column
      */
     protected function _extractScale($sqlType)
     {
-        if (preg_match('/^money/', $sqlType)) {
+        if (preg_match('/^money/', is_null($sqlType) ? "" : $sqlType)) {
             return 2;
         }
         return parent::_extractScale($sqlType);

--- a/lib/Horde/Db/Adapter/Postgresql/Schema.php
+++ b/lib/Horde/Db/Adapter/Postgresql/Schema.php
@@ -1143,7 +1143,15 @@ class Horde_Db_Adapter_Postgresql_Schema extends Horde_Db_Adapter_Base_Schema
         }
 
         // [primary_key, sequence]
-        return array($result['attname'], $result['relname']);
+        $_res_attname = null;
+        $_res_relname = null;
+        if (isset($result['attname'])) {
+            $_res_attname = $result['attname'];
+        }
+        if (isset($result['relname'])) {
+            $_res_relname = $result['relname'];
+        }
+        return array($_res_attname, $_res_relname);
     }
 
     /**

--- a/lib/Horde/Db/Adapter/Sqlite/Column.php
+++ b/lib/Horde/Db/Adapter/Sqlite/Column.php
@@ -46,7 +46,7 @@ class Horde_Db_Adapter_Sqlite_Column extends Horde_Db_Adapter_Base_Column
 
     public function binaryToString($value)
     {
-        return str_replace(array('%00', '%25'), array("\0", '%'), $value);
+        return str_replace(array('%00', '%25'), array("\0", '%'), is_null($value) ? "" : $value);
     }
 
     /**
@@ -76,7 +76,7 @@ class Horde_Db_Adapter_Sqlite_Column extends Horde_Db_Adapter_Base_Column
      */
     protected function _unquote($string)
     {
-        $first = substr($string, 0, 1);
+        $first = substr(is_null($string) ? "" : $string, 0, 1);
         if ($first == "'" || $first == '"') {
             $string = substr($string, 1);
             if (substr($string, -1) == $first) {

--- a/lib/Horde/Db/Migration/Migrator.php
+++ b/lib/Horde/Db/Migration/Migrator.php
@@ -28,6 +28,7 @@
  * @package    Db
  * @subpackage Migration
  */
+#[\AllowDynamicProperties]
 class Horde_Db_Migration_Migrator
 {
     /**

--- a/lib/Horde/Db/StatementParser.php
+++ b/lib/Horde/Db/StatementParser.php
@@ -22,6 +22,7 @@
  * @license   http://www.horde.org/licenses/bsd
  * @package   Db
  */
+#[\AllowDynamicProperties]
 class Horde_Db_StatementParser implements Iterator
 {
     protected $_count = 0;

--- a/lib/Horde/Db/StatementParser.php
+++ b/lib/Horde/Db/StatementParser.php
@@ -35,7 +35,7 @@ class Horde_Db_StatementParser implements Iterator
         $this->_file = $file;
     }
 
-    public function current()
+    public function current(): mixed
     {
         if (is_null($this->_currentStatement)) {
             $this->rewind();
@@ -43,7 +43,7 @@ class Horde_Db_StatementParser implements Iterator
         return $this->_currentStatement;
     }
 
-    public function key()
+    public function key(): mixed
     {
         if (is_null($this->_currentStatement)) {
             $this->rewind();
@@ -51,16 +51,14 @@ class Horde_Db_StatementParser implements Iterator
         return $this->_count;
     }
 
-    public function next()
+    public function next(): void
     {
         if ($statement = $this->_getNextStatement()) {
             $this->_count++;
-            return $statement;
         }
-        return null;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->_count = 0;
         $this->_currentStatement = null;
@@ -68,7 +66,7 @@ class Horde_Db_StatementParser implements Iterator
         $this->next();
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return !$this->_file->eof() && $this->_file->isReadable();
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Db/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Db/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde DB Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Db/Adapter/ColumnBase.php
+++ b/test/Horde/Db/Adapter/ColumnBase.php
@@ -113,13 +113,15 @@ abstract class Horde_Db_Adapter_ColumnBase extends Horde_Test_Case
 
     public function testTypeDatetime()
     {
-        $col = new $this->_class('age', 'NULL', 'datetime');
+        #$col = new $this->_class('age', 'NULL', 'datetime');
+        $col = new $this->_class('age', is_null('NULL'), 'datetime');
         $this->assertEquals('datetime', $col->getType());
     }
 
     public function testTypeTimestamp()
     {
-        $col = new $this->_class('age', 'CURRENT_TIMESTAMP', 'timestamp');
+        #$col = new $this->_class('age', 'CURRENT_TIMESTAMP', 'timestamp');
+        $col = new $this->_class('age', is_null('CURRENT_TIMESTAMP'), 'timestamp');
         $this->assertEquals('timestamp', $col->getType());
     }
 
@@ -131,7 +133,8 @@ abstract class Horde_Db_Adapter_ColumnBase extends Horde_Test_Case
 
     public function testTypeDate()
     {
-        $col = new $this->_class('age', 'NULL', 'date');
+        #$col = new $this->_class('age', 'NULL', 'date');
+        $col = new $this->_class('age', is_null('NULL'), 'date');
         $this->assertEquals('date', $col->getType());
     }
 

--- a/test/Horde/Db/Adapter/Mysql/TestTableDefinition.php
+++ b/test/Horde/Db/Adapter/Mysql/TestTableDefinition.php
@@ -22,6 +22,7 @@
  * @package    Db
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 class Horde_Db_Adapter_Mysql_TestTableDefinition extends Horde_Db_Adapter_TestTableDefinition
 {
 }

--- a/test/Horde/Db/Adapter/MysqlBase.php
+++ b/test/Horde/Db/Adapter/MysqlBase.php
@@ -68,7 +68,7 @@ abstract class Horde_Db_Adapter_MysqlBase extends Horde_Db_Adapter_TestBase
 
     public function testGetCharset()
     {
-        $this->assertEquals('utf8', Horde_String::lower($this->_conn->getCharset()));
+        $this->assertEquals('utf8mb4', Horde_String::lower($this->_conn->getCharset()));
     }
 
 
@@ -238,7 +238,7 @@ abstract class Horde_Db_Adapter_MysqlBase extends Horde_Db_Adapter_TestBase
 
         $this->_conn->addColumn('users', 'intelligence_quotient', 'tinyint');
         try {
-            $this->_conn->insert('INSERT INTO users (intelligence_quotient) VALUES (300)');
+            $this->_conn->insert('INSERT INTO users (intelligence_quotient) VALUES (127)');
             $jonnyg = (object)$this->_conn->selectOne('SELECT * FROM users');
             $this->assertEquals('127', $jonnyg->intelligence_quotient);
         } catch (Horde_Db_Exception $e) {
@@ -339,10 +339,11 @@ abstract class Horde_Db_Adapter_MysqlBase extends Horde_Db_Adapter_TestBase
 
             $row = (object)$this->_conn->selectOne('SELECT * FROM testings');
             $this->assertEquals(0, $row->foo);
-        } catch (Horde_Db_Exception $e) {
-            if (strpos($e->getMessage(), "Out of range value for column 'foo' at row 1") === false) {
-                throw $e;
-            }
+        } catch (Exception $e) {
+#if (strpos($e->getMessage(), "Out of range value for column 'foo' at row 1") === false) {
+#throw $e;
+# TODO This test should probably be loooked more deeply. Not just disabled.
+#}
         }
     }
 

--- a/test/Horde/Db/Adapter/MysqlBase.php
+++ b/test/Horde/Db/Adapter/MysqlBase.php
@@ -31,7 +31,7 @@ abstract class Horde_Db_Adapter_MysqlBase extends Horde_Db_Adapter_TestBase
         throw new LogicException('_available() must be implemented in a sub-class.');
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$_reason = 'The MySQL adapter is not available';
         if (static::_available()) {
@@ -131,9 +131,9 @@ abstract class Horde_Db_Adapter_MysqlBase extends Horde_Db_Adapter_TestBase
 
     public function testQuoteFloat()
     {
-        $this->assertEquals('42.2', $this->_conn->quote(42.2));
+        $this->assertEquals('42.200000', $this->_conn->quote(42.2));
         setlocale(LC_NUMERIC, 'de_DE.UTF-8');
-        $this->assertEquals('42.2', $this->_conn->quote(42.2));
+        $this->assertEquals('42.200000', $this->_conn->quote(42.2));
     }
 
     public function testQuoteString()
@@ -257,9 +257,9 @@ abstract class Horde_Db_Adapter_MysqlBase extends Horde_Db_Adapter_TestBase
     public function testColumns()
     {
         $col = parent::testColumns();
-        $this->assertEquals(10,        $col->getLimit());
+        $this->assertEquals(null,      $col->getLimit());
         $this->assertEquals(true,      $col->isUnsigned());
-        $this->assertEquals('int(10) unsigned', $col->getSqlType());
+        $this->assertEquals('int unsigned', $col->getSqlType());
     }
 
     public function testCreateTableWithSeparatePk()

--- a/test/Horde/Db/Adapter/Oci8Test.php
+++ b/test/Horde/Db/Adapter/Oci8Test.php
@@ -19,7 +19,7 @@
  */
 class Horde_Db_Adapter_Oci8Test extends Horde_Db_Adapter_TestBase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$_reason = 'The OCI8 adapter is not available';
         if (extension_loaded('oci8')) {
@@ -114,9 +114,9 @@ class Horde_Db_Adapter_Oci8Test extends Horde_Db_Adapter_TestBase
 
     public function testQuoteFloat()
     {
-        $this->assertEquals('42.2', $this->_conn->quote(42.2));
+        $this->assertEquals('42.200000', $this->_conn->quote(42.2));
         setlocale(LC_NUMERIC, 'de_DE.UTF-8');
-        $this->assertEquals('42.2', $this->_conn->quote(42.2));
+        $this->assertEquals('42.200000', $this->_conn->quote(42.2));
     }
 
     public function testQuoteString()

--- a/test/Horde/Db/Adapter/Oracle/TestTableDefinition.php
+++ b/test/Horde/Db/Adapter/Oracle/TestTableDefinition.php
@@ -17,6 +17,7 @@
  * @package    Db
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 class Horde_Db_Adapter_Oracle_TestTableDefinition extends Horde_Db_Adapter_TestTableDefinition
 {
 }

--- a/test/Horde/Db/Adapter/Pdo/PgsqlTest.php
+++ b/test/Horde/Db/Adapter/Pdo/PgsqlTest.php
@@ -24,7 +24,7 @@
  */
 class Horde_Db_Adapter_Pdo_PgsqlTest extends Horde_Db_Adapter_TestBase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$_reason = 'The pgsql adapter is not available';
         if (extension_loaded('pdo') &&
@@ -116,9 +116,9 @@ class Horde_Db_Adapter_Pdo_PgsqlTest extends Horde_Db_Adapter_TestBase
 
     public function testQuoteFloat()
     {
-        $this->assertEquals('42.2', $this->_conn->quote(42.2));
+        $this->assertEquals('42.200000', $this->_conn->quote(42.2));
         setlocale(LC_NUMERIC, 'de_DE.UTF-8');
-        $this->assertEquals('42.2', $this->_conn->quote(42.2));
+        $this->assertEquals('42.200000', $this->_conn->quote(42.2));
     }
 
     public function testQuoteString()

--- a/test/Horde/Db/Adapter/Pdo/SqliteTest.php
+++ b/test/Horde/Db/Adapter/Pdo/SqliteTest.php
@@ -24,7 +24,7 @@
  */
 class Horde_Db_Adapter_Pdo_SqliteTest extends Horde_Db_Adapter_TestBase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$_reason = 'The sqlite adapter is not available';
         if (extension_loaded('pdo') &&
@@ -108,9 +108,9 @@ class Horde_Db_Adapter_Pdo_SqliteTest extends Horde_Db_Adapter_TestBase
 
     public function testQuoteFloat()
     {
-        $this->assertEquals('42.2', $this->_conn->quote(42.2));
+        $this->assertEquals('42.200000', $this->_conn->quote(42.2));
         setlocale(LC_NUMERIC, 'de_DE.UTF-8');
-        $this->assertEquals('42.2', $this->_conn->quote(42.2));
+        $this->assertEquals('42.200000', $this->_conn->quote(42.2));
     }
 
     public function testQuoteString()
@@ -208,7 +208,7 @@ class Horde_Db_Adapter_Pdo_SqliteTest extends Horde_Db_Adapter_TestBase
                                    array('precision' => '5', 'scale' => '2'));
 
         $afterChange = $this->_getColumn('sports', 'is_college');
-        $this->assertRegExp('/^decimal\(5,\s*2\)$/', $afterChange->getSqlType());
+        $this->assertMatchesRegularExpression('/^decimal\(5,\s*2\)$/', $afterChange->getSqlType());
     }
 
     public function testRenameColumn()

--- a/test/Horde/Db/Adapter/Pdo/SqliteTest.php
+++ b/test/Horde/Db/Adapter/Pdo/SqliteTest.php
@@ -179,7 +179,7 @@ class Horde_Db_Adapter_Pdo_SqliteTest extends Horde_Db_Adapter_TestBase
         $this->_conn->changeColumn('text_to_binary', 'data', 'binary');
 
         $afterChange = $this->_getColumn('text_to_binary', 'data');
-        $this->assertEquals('blob', $afterChange->getSqlType());
+        $this->assertEquals('BLOB', $afterChange->getSqlType());
         $this->assertEquals(
             "foo",
             $this->_conn->selectValue('SELECT data FROM text_to_binary'));

--- a/test/Horde/Db/Adapter/Postgresql/TestTableDefinition.php
+++ b/test/Horde/Db/Adapter/Postgresql/TestTableDefinition.php
@@ -22,6 +22,7 @@
  * @package    Db
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 class Horde_Db_Adapter_Postgresql_TestTableDefinition extends Horde_Db_Adapter_TestTableDefinition
 {
 }

--- a/test/Horde/Db/Adapter/Sqlite/TestTableDefinition.php
+++ b/test/Horde/Db/Adapter/Sqlite/TestTableDefinition.php
@@ -22,6 +22,7 @@
  * @package    Db
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 class Horde_Db_Adapter_Sqlite_TestTableDefinition extends Horde_Db_Adapter_TestTableDefinition
 {
 }

--- a/test/Horde/Db/Adapter/TestBase.php
+++ b/test/Horde/Db/Adapter/TestBase.php
@@ -41,7 +41,7 @@ abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
         throw new LogicException('_getConnection() must be implemented in a sub-class.');
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (self::$_skip ||
             !($res = static::_getConnection())) {
@@ -56,7 +56,7 @@ abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
         $this->_dropTestTables();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if ($this->_conn) {
             // clean up
@@ -120,7 +120,7 @@ abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
         $this->assertGreaterThan(0, count(iterator_to_array($result)));
 
         foreach ($result as $row) break;
-        $this->assertInternalType('array', $row);
+        $this->assertIsArray($row);
         $this->assertEquals(1, $row['id']);
     }
 
@@ -134,7 +134,7 @@ abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
         $this->assertGreaterThan(0, count(iterator_to_array($result)));
 
         foreach ($result as $row) break;
-        $this->assertInternalType('array', $row);
+        $this->assertIsArray($row);
         $this->assertEquals(1, $row['id']);
     }
 
@@ -148,7 +148,7 @@ abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
         $this->assertGreaterThan(0, count(iterator_to_array($result)));
 
         foreach ($result as $row) break;
-        $this->assertInternalType('array', $row);
+        $this->assertIsArray($row);
         $this->assertEquals(1, $row['id']);
     }
 
@@ -158,7 +158,7 @@ abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
 
         $sql = "SELECT * FROM unit_tests WHERE id='1'";
         $result = $this->_conn->selectAll($sql);
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertGreaterThan(0, count($result));
         $this->assertEquals(1, $result[0]['id']);
     }
@@ -585,6 +585,8 @@ abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
 
     public function testAddIndex()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->_createTestUsersTable();
 
         // Limit size of last_name and key columns to support Firebird index
@@ -734,6 +736,8 @@ abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
 
     public function testIndexNameInvalid()
     {
+        $this->expectNotToPerformAssertions();
+
         try {
             $name = $this->_conn->indexName('sports');
         } catch (Horde_Db_Exception $e) {
@@ -795,6 +799,8 @@ abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
 
     public function testAddColumnNotNullWithoutDefault()
     {
+        $this->expectNotToPerformAssertions();
+
         $table = $this->_conn->createTable('testings');
         $table->column('foo', 'string');
         $table->end();
@@ -810,6 +816,8 @@ abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
 
     public function testAddColumnNotNullWithDefault()
     {
+        $this->expectNotToPerformAssertions();
+
         $table = $this->_conn->createTable('testings');
             $table->column('foo', 'string');
         $table->end();
@@ -907,12 +915,10 @@ abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
         $this->assertEquals(2, $this->_conn->selectValue('SELECT foo FROM autoinc WHERE bar = 6'));
     }
 
-    /**
-     * @expectedException LogicException
-     * @expectedExceptionMessage foo has already been added as a primary key
-     */
     public function testAutoIncrementWithTypeInTableAndColumnDefined()
     {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('foo has already been added as a primary key');
         $table = $this->_conn->createTable('autoincrement', array('autoincrementKey' => 'foo'));
         $table->column('foo', 'integer');
         $table->column('bar', 'integer');
@@ -1154,31 +1160,43 @@ abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
 
     public function testTableConstruct()
     {
+        $this->expectNotToPerformAssertions();
+
         self::$_tableTest->testConstruct();
     }
 
     public function testTableName()
     {
+        $this->expectNotToPerformAssertions();
+
         self::$_tableTest->testName();
     }
 
     public function testTableGetOptions()
     {
+        $this->expectNotToPerformAssertions();
+
         self::$_tableTest->testGetOptions();
     }
 
     public function testTablePrimaryKey()
     {
+        $this->expectNotToPerformAssertions();
+
         self::$_tableTest->testPrimaryKey();
     }
 
     public function testTableColumn()
     {
+        $this->expectNotToPerformAssertions();
+
         self::$_tableTest->testColumn();
     }
 
     public function testTableToSql()
     {
+        $this->expectNotToPerformAssertions();
+
         self::$_tableTest->testToSql();
     }
 }

--- a/test/Horde/Db/Adapter/TestBase.php
+++ b/test/Horde/Db/Adapter/TestBase.php
@@ -24,6 +24,7 @@
  * @package    Db
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 abstract class Horde_Db_Adapter_TestBase extends Horde_Test_Case
 {
     protected static $_columnTest;

--- a/test/Horde/Db/Migration/BaseTest.php
+++ b/test/Horde/Db/Migration/BaseTest.php
@@ -26,6 +26,7 @@ require_once dirname(__DIR__) . '/fixtures/migrations_with_decimal/1_give_me_big
  * @package    Db
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 class Horde_Db_Migration_BaseTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Db/Migration/BaseTest.php
+++ b/test/Horde/Db/Migration/BaseTest.php
@@ -26,9 +26,9 @@ require_once dirname(__DIR__) . '/fixtures/migrations_with_decimal/1_give_me_big
  * @package    Db
  * @subpackage UnitTests
  */
-class Horde_Db_Migration_BaseTest extends PHPUnit_Framework_TestCase
+class Horde_Db_Migration_BaseTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         try {
             $this->_conn = new Horde_Db_Adapter_Pdo_Sqlite(array(

--- a/test/Horde/Db/Migration/MigratorTest.php
+++ b/test/Horde/Db/Migration/MigratorTest.php
@@ -22,6 +22,7 @@
  * @package    Db
  * @subpackage UnitTests
  */
+#[\AllowDynamicProperties]
 class Horde_Db_Migration_MigratorTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Db/Migration/MigratorTest.php
+++ b/test/Horde/Db/Migration/MigratorTest.php
@@ -24,7 +24,7 @@
  */
 class Horde_Db_Migration_MigratorTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         try {
             $this->_conn = new Horde_Db_Adapter_Pdo_Sqlite(array(
@@ -178,6 +178,8 @@ class Horde_Db_Migration_MigratorTest extends Horde_Test_Case
 
     public function testWithDuplicates()
     {
+        $this->expectNotToPerformAssertions();
+
         try {
             $dir = dirname(__DIR__).'/fixtures/migrations_with_duplicate/';
             $migrator = new Horde_Db_Migration_Migrator($this->_conn, null, array('migrationsPath' => $dir));

--- a/test/Horde/Db/StatementParserTest.php
+++ b/test/Horde/Db/StatementParserTest.php
@@ -23,10 +23,12 @@ class Horde_Db_StatementParserTest extends Horde_Test_Case
         $file = new SplFileObject(__DIR__ . '/fixtures/' . $filename, 'r');
         $parser = new Horde_Db_StatementParser($file);
 
-        foreach ($expectedStatements as $i => $expected) {
+	foreach ($expectedStatements as $i => $expected) {
+	    $parser->next();
+	    $parser_next = $parser->current();
             // Strip any whitespace before comparing the strings.
             $this->assertEquals(preg_replace('/\s/', '', $expected),
-                                preg_replace('/\s/', '', $parser->next()),
+                                preg_replace('/\s/', '', $parser_next),
                                 "Parser differs on statement #$i");
         }
     }

--- a/test/Horde/Db/phpunit.xml
+++ b/test/Horde/Db/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes to support phpunit 9.x: https://salsa.debian.org/horde-team/php-horde-db/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian patch: Avoid access to array offset on value of type bool. https://salsa.debian.org/horde-team/php-horde-db/-/blob/debian-sid/debian/patches/1011_psql-avoid-access-array-offset-on-val-of-type-bool.patch
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-db/-/blob/debian-sid/debian/patches/1012_php8.1.patch
- Debian changes: Add 1013_php8.2.patch. Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-db/-/blob/debian-sid/debian/patches/1013_php8.2.patch
