### PR TITLE
feat: Lazy DB Handle configuration

### DIFF
--- a/src/Adapter/Base.php
+++ b/src/Adapter/Base.php
@@ -180,7 +180,8 @@ abstract class Base implements Adapter
             $this->schemaClass = __CLASS__ . '_Schema';
         }
 
-        $this->connect();
+        // Connection is deferred until first query (lazy connect).
+        // Subclass methods that need $this->connection call ensureConnected().
     }
 
     /**
@@ -204,8 +205,10 @@ abstract class Base implements Adapter
      */
     public function __wakeup()
     {
-        $this->schema->setAdapter($this);
-        $this->connect();
+        if ($this->schema) {
+            $this->schema->setAdapter($this);
+        }
+        // Connection is deferred until first query (lazy connect).
     }
 
     /**
@@ -470,7 +473,22 @@ abstract class Base implements Adapter
      */
     public function rawConnection()
     {
+        $this->ensureConnected();
         return $this->connection;
+    }
+
+    /**
+     * Ensure the database connection is established.
+     *
+     * Called by subclass methods that need $this->connection. If not yet
+     * connected, triggers connect(). Safe to call multiple times — returns
+     * immediately when already active.
+     */
+    protected function ensureConnected(): void
+    {
+        if (!$this->active) {
+            $this->connect();
+        }
     }
 
 

--- a/src/Adapter/Base.php
+++ b/src/Adapter/Base.php
@@ -28,6 +28,7 @@ use Horde_Support_Stub;
 use BadMethodCallException;
 use Horde_Support_Backtrace;
 use Horde\Db\Value\Binary;
+use Horde_Db_Value_Binary;
 
 /**
  *
@@ -885,7 +886,7 @@ abstract class Base implements Adapter
         $sql = array_shift($sqlPieces);
         while (count($sqlPieces)) {
             $value = array_shift($args);
-            if ($no_binary && $value instanceof Binary) {
+            if ($no_binary && ($value instanceof Binary || $value instanceof Horde_Db_Value_Binary)) {
                 $sql_value = '<binary_data>';
             } else {
                 $sql_value = $this->quote($value);

--- a/src/Adapter/Base/Schema.php
+++ b/src/Adapter/Base/Schema.php
@@ -28,6 +28,8 @@ use InvalidArgumentException;
 use Horde_Date;
 use DateTime;
 use Horde_String;
+use Horde_Db_Adapter_Base_TableDefinition;
+use Horde_Db_Value;
 
 /**
  * Base class for managing database schemes and handling database-specific SQL
@@ -250,7 +252,7 @@ abstract class Schema
             return $value->quotedId();
         }
 
-        if ($value instanceof Value) {
+        if ($value instanceof Value || $value instanceof Horde_Db_Value) {
             return $value->quote($this->adapter);
         }
 
@@ -586,7 +588,7 @@ abstract class Schema
      */
     public function endTable($name, $options = [])
     {
-        if ($name instanceof TableDefinition) {
+        if ($name instanceof TableDefinition || $name instanceof Horde_Db_Adapter_Base_TableDefinition) {
             $tableDefinition = $name;
             $options = array_merge($tableDefinition->getOptions(), $options);
         } else {

--- a/src/Adapter/Mysql/Schema.php
+++ b/src/Adapter/Mysql/Schema.php
@@ -24,6 +24,7 @@ use Horde\Db\Adapter\Base\Index;
 use Horde\Db\Adapter\Base\TableDefinition;
 use Horde\Db\DbException;
 use Horde_String;
+use Horde_Db_Adapter_Base_TableDefinition;
 
 /**
  * Class for MySQL-specific managing of database schemes and handling of SQL
@@ -311,7 +312,7 @@ class Schema extends BaseSchema
      */
     public function endTable($name, $options = [])
     {
-        if ($name instanceof TableDefinition) {
+        if ($name instanceof TableDefinition || $name instanceof Horde_Db_Adapter_Base_TableDefinition) {
             $options = array_merge($name->getOptions(), $options);
         }
         if (isset($options['options'])) {

--- a/src/Adapter/Mysqli.php
+++ b/src/Adapter/Mysqli.php
@@ -175,7 +175,7 @@ class Mysqli extends Base
             if ($charset === 'utf8') {
                 $charset = 'utf8mb4';
             }
-            $this->schema->setCharset($charset);
+            $this->setCharset($charset);
         }
 
         $this->hasMysqliFetchAll = function_exists('mysqli_fetch_all');

--- a/src/Adapter/Mysqli.php
+++ b/src/Adapter/Mysqli.php
@@ -199,8 +199,11 @@ class Mysqli extends Base
      */
     public function isActive()
     {
+        if (!$this->active) {
+            return false;
+        }
         $this->lastQuery = 'SELECT 1';
-        return isset($this->connection) && $this->connection->query('SELECT 1');
+        return (bool) $this->connection->query('SELECT 1');
     }
 
 
@@ -217,6 +220,8 @@ class Mysqli extends Base
      */
     public function quoteString($string)
     {
+        $this->ensureConnected();
+
         return "'" . $this->connection->real_escape_string($string) . "'";
     }
 
@@ -330,6 +335,8 @@ class Mysqli extends Base
      */
     public function execute($sql, $arg1 = null, $arg2 = null)
     {
+        $this->ensureConnected();
+
         if (is_array($arg1)) {
             $query = $this->replaceParameters($sql, $arg1);
             $name = $arg2;
@@ -383,6 +390,8 @@ class Mysqli extends Base
      */
     public function beginDbTransaction()
     {
+        $this->ensureConnected();
+
         $this->connection->autocommit(false);
         $this->transactionStarted++;
     }
@@ -392,6 +401,8 @@ class Mysqli extends Base
      */
     public function commitDbTransaction()
     {
+        $this->ensureConnected();
+
         $this->transactionStarted--;
         if (!$this->transactionStarted) {
             $this->connection->commit();
@@ -405,6 +416,8 @@ class Mysqli extends Base
      */
     public function rollbackDbTransaction()
     {
+        $this->ensureConnected();
+
         if (!$this->transactionStarted) {
             return;
         }

--- a/src/Adapter/Oci8.php
+++ b/src/Adapter/Oci8.php
@@ -299,6 +299,8 @@ class Oci8 extends Base
      */
     public function execute($sql, $arg1 = null, $arg2 = null, $lobs = [])
     {
+        $this->ensureConnected();
+
         if (is_array($arg1)) {
             $query = $this->replaceParameters($sql, $arg1);
             $name = $arg2;
@@ -519,6 +521,8 @@ class Oci8 extends Base
      */
     public function commitDbTransaction()
     {
+        $this->ensureConnected();
+
         $this->transactionStarted--;
         if (!$this->transactionStarted) {
             if (!oci_commit($this->connection)) {
@@ -533,6 +537,8 @@ class Oci8 extends Base
      */
     public function rollbackDbTransaction()
     {
+        $this->ensureConnected();
+
         if (!$this->transactionStarted) {
             return;
         }

--- a/src/Adapter/Oci8.php
+++ b/src/Adapter/Oci8.php
@@ -24,6 +24,8 @@ use Horde\Db\Value\Text;
 use Horde\Db\Value\Binary;
 use Horde_Support_Timer;
 use Horde_String;
+use Horde_Db_Value_Binary;
+use Horde_Db_Value_Text;
 
 /**
  *
@@ -319,7 +321,7 @@ class Oci8 extends Base
         $descriptors = [];
         foreach ($lobs as $name => $lob) {
             $descriptors[$name] = oci_new_descriptor($this->connection, OCI_DTYPE_LOB);
-            oci_bind_by_name($stmt, ':' . $name, $descriptors[$name], -1, $lob instanceof Text ? OCI_B_CLOB : OCI_B_BLOB);
+            oci_bind_by_name($stmt, ':' . $name, $descriptors[$name], -1, ($lob instanceof Text || $lob instanceof Horde_Db_Value_Text) ? OCI_B_CLOB : OCI_B_BLOB);
         }
 
         $flags = $lobs
@@ -494,11 +496,11 @@ class Oci8 extends Base
     {
         $blobs = $locators = [];
         foreach ($fields as $column => &$field) {
-            if ($field instanceof Binary
-                || $field instanceof Text) {
+            if ($field instanceof Binary || $field instanceof Horde_Db_Value_Binary
+                || $field instanceof Text || $field instanceof Horde_Db_Value_Text) {
                 $blobs[$this->quoteColumnName($column)] = $field;
                 $locators[] = ':' . $this->quoteColumnName($column);
-                $field = $field instanceof Text
+                $field = ($field instanceof Text || $field instanceof Horde_Db_Value_Text)
                     ? 'EMPTY_CLOB()'
                     : 'EMPTY_BLOB()';
             } else {

--- a/src/Adapter/Pdo/Base.php
+++ b/src/Adapter/Pdo/Base.php
@@ -26,6 +26,8 @@ use Horde\Db\DbException;
 use Horde\Db\Value\Binary;
 use Horde_Support_Timer;
 use Horde\Db\Value;
+use Horde_Db_Value;
+use Horde_Db_Value_Binary;
 
 /**
  *
@@ -339,7 +341,7 @@ abstract class Base extends BaseAdapter
         $placeholders = $values = $binary = [];
         $binary_cnt = 0;
         foreach ($fields as $name => $value) {
-            if ($value instanceof Binary) {
+            if ($value instanceof Binary || $value instanceof Horde_Db_Value_Binary) {
                 $placeholders[] = ':binary' . $binary_cnt++;
                 $binary[] = $value->stream;
             } else {
@@ -395,7 +397,7 @@ abstract class Base extends BaseAdapter
         $binary_cnt = 0;
 
         foreach ($fields as $field => $value) {
-            if ($value instanceof Value) {
+            if ($value instanceof Value || $value instanceof Horde_Db_Value) {
                 $fnames[] = $this->quoteColumnName($field) . ' = :binary' . $binary_cnt++;
                 $binary_values[] = $value->stream;
             } else {

--- a/src/Adapter/Pdo/Base.php
+++ b/src/Adapter/Pdo/Base.php
@@ -83,10 +83,12 @@ abstract class Base extends BaseAdapter
      */
     public function isActive()
     {
+        if (!$this->active) {
+            return false;
+        }
         $this->lastQuery = $sql = 'SELECT 1';
         try {
-            return isset($this->connection)
-                && $this->connection->query($sql);
+            return (bool) $this->connection->query($sql);
         } catch (PDOException $e) {
             throw new DbException($e);
         }
@@ -237,6 +239,8 @@ abstract class Base extends BaseAdapter
      */
     public function execute($sql, $arg1 = null, $arg2 = null)
     {
+        $this->ensureConnected();
+
         if (is_array($arg1)) {
             $query = $this->replaceParameters($sql, $arg1);
             $name = $arg2;
@@ -279,6 +283,8 @@ abstract class Base extends BaseAdapter
      */
     protected function executePrepared($sql, $values, $binary_values)
     {
+        $this->ensureConnected();
+
         $query = $this->replaceParameters($sql, $values);
         try {
             $stmt = $this->connection->prepare($query);
@@ -455,6 +461,8 @@ abstract class Base extends BaseAdapter
      */
     public function beginDbTransaction()
     {
+        $this->ensureConnected();
+
         if (!$this->transactionStarted) {
             try {
                 $this->connection->beginTransaction();
@@ -470,6 +478,8 @@ abstract class Base extends BaseAdapter
      */
     public function commitDbTransaction()
     {
+        $this->ensureConnected();
+
         $this->transactionStarted--;
         if (!$this->transactionStarted) {
             try {
@@ -486,6 +496,8 @@ abstract class Base extends BaseAdapter
      */
     public function rollbackDbTransaction()
     {
+        $this->ensureConnected();
+
         if (!$this->transactionStarted) {
             return;
         }
@@ -512,6 +524,8 @@ abstract class Base extends BaseAdapter
      */
     public function quoteString($string)
     {
+        $this->ensureConnected();
+
         try {
             return $this->connection->quote($string);
         } catch (PDOException $e) {

--- a/src/Adapter/Pdo/Mysql.php
+++ b/src/Adapter/Pdo/Mysql.php
@@ -82,7 +82,7 @@ class Mysql extends Base
             if ($charset === 'utf8') {
                 $charset = 'utf8mb4';
             }
-            $this->schema->setCharset($charset);
+            $this->setCharset($charset);
         }
     }
 

--- a/src/Adapter/Pdo/Pgsql.php
+++ b/src/Adapter/Pdo/Pgsql.php
@@ -67,12 +67,12 @@ class Pgsql extends Base
         // Temporarily set the client message level above error to prevent unintentional
         // error messages in the logs when working on a PostgreSQL database server that
         // does not support standard conforming strings.
-        $clientMinMessagesOld = $this->schema->getClientMinMessages();
-        $this->schema->setClientMinMessages('panic');
+        $clientMinMessagesOld = $this->getClientMinMessages();
+        $this->setClientMinMessages('panic');
 
         $hasSupport = $this->selectValue('SHOW standard_conforming_strings');
 
-        $this->schema->setClientMinMessages($clientMinMessagesOld);
+        $this->setClientMinMessages($clientMinMessagesOld);
         return $hasSupport;
     }
 
@@ -163,7 +163,7 @@ class Pgsql extends Base
 
         // If neither pk nor sequence name is given, look them up.
         if (!($pk || $sequenceName)) {
-            [$pk, $sequenceName] = $this->schema->pkAndSequenceFor($table);
+            [$pk, $sequenceName] = $this->pkAndSequenceFor($table);
         }
 
         // Otherwise, insert then grab last_insert_id.
@@ -176,8 +176,8 @@ class Pgsql extends Base
         // Don't fetch last insert id for a table without a pk.
         if ($pk
             && ($sequenceName
-             || $sequenceName = $this->schema->defaultSequenceName($table, $pk))) {
-            $this->schema->resetPkSequence($table, $pk, $sequenceName);
+             || $sequenceName = $this->defaultSequenceName($table, $pk))) {
+            $this->resetPkSequence($table, $pk, $sequenceName);
             return $this->lastInsertId($table, $sequenceName);
         }
         return 0;
@@ -244,9 +244,9 @@ class Pgsql extends Base
         }
 
         if (!empty($this->config['client_min_messages'])) {
-            $this->schema->setClientMinMessages($this->config['client_min_messages']);
+            $this->setClientMinMessages($this->config['client_min_messages']);
         }
-        $this->schema->setSchemaSearchPath(!empty($this->config['schema_search_path']) || !empty($this->config['schema_order']));
+        $this->setSchemaSearchPath(!empty($this->config['schema_search_path']) || !empty($this->config['schema_order']));
     }
 
     /**
@@ -302,6 +302,6 @@ class Pgsql extends Base
      */
     protected function lastInsertId($table, $sequenceName)
     {
-        return (int) $this->selectValue('SELECT currval(' . $this->schema->quoteSequenceName($sequenceName) . ')');
+        return (int) $this->selectValue('SELECT currval(' . $this->quoteSequenceName($sequenceName) . ')');
     }
 }

--- a/src/Adapter/Pdo/Sqlite.php
+++ b/src/Adapter/Pdo/Sqlite.php
@@ -74,6 +74,7 @@ class Sqlite extends Base
      */
     public function supportsCountDistinct()
     {
+        $this->ensureConnected();
         return $this->sqliteVersion >= '3.2.6';
     }
 
@@ -90,6 +91,7 @@ class Sqlite extends Base
 
     public function supportsAutoIncrement()
     {
+        $this->ensureConnected();
         return $this->sqliteVersion >= '3.1.0';
     }
 

--- a/test/Integration/Mysql/Psr4AdapterTest.php
+++ b/test/Integration/Mysql/Psr4AdapterTest.php
@@ -42,6 +42,9 @@ class Psr4AdapterTest extends DatabaseTestCase
 
     public function testConnection()
     {
+        // Lazy connect: not active until first query
+        $this->assertFalse($this->conn->isActive());
+        $this->conn->selectValue('SELECT 1');
         $this->assertTrue($this->conn->isActive());
     }
 

--- a/test/Integration/Oracle/Psr4AdapterTest.php
+++ b/test/Integration/Oracle/Psr4AdapterTest.php
@@ -49,6 +49,9 @@ class Psr4AdapterTest extends DatabaseTestCase
 
     public function testConnection()
     {
+        // Lazy connect: not active until first query
+        $this->assertFalse($this->conn->isActive());
+        $this->conn->selectValue('SELECT 1 FROM DUAL');
         $this->assertTrue($this->conn->isActive());
     }
 

--- a/test/Integration/Postgres/Psr4AdapterTest.php
+++ b/test/Integration/Postgres/Psr4AdapterTest.php
@@ -42,6 +42,9 @@ class Psr4AdapterTest extends DatabaseTestCase
 
     public function testConnection()
     {
+        // Lazy connect: not active until first query
+        $this->assertFalse($this->conn->isActive());
+        $this->conn->selectValue('SELECT 1');
         $this->assertTrue($this->conn->isActive());
     }
 

--- a/test/Integration/Sqlite/LazyConnectIntegrationTest.php
+++ b/test/Integration/Sqlite/LazyConnectIntegrationTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @category Horde
+ * @package  Db
+ * @license  http://www.horde.org/licenses/bsd
+ */
+
+declare(strict_types=1);
+
+namespace Horde\Db\Test\Integration\Sqlite;
+
+use Horde\Db\Adapter\Pdo\Sqlite;
+use Horde\Db\Test\Integration\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Integration tests for lazy database connection with real SQLite.
+ *
+ * Verifies full round-trip behaviour: construction without connection,
+ * then real SQL execution on first query.
+ *
+ * @category Horde
+ * @package  Db
+ * @license  http://www.horde.org/licenses/bsd
+ */
+#[CoversClass(Sqlite::class)]
+class LazyConnectIntegrationTest extends DatabaseTestCase
+{
+    private Sqlite $conn;
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('PDO SQLite extension not available');
+        }
+
+        $config = $this->getSqliteConfig();
+        $this->conn = new Sqlite($config);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->conn) && $this->conn->isActive()) {
+            $this->conn->disconnect();
+        }
+    }
+
+    /**
+     * Full round-trip: construct, quote (no connect), CREATE, INSERT, SELECT.
+     */
+    public function testFullRoundTripWithLazyConnect(): void
+    {
+        // Quoting works before any connection
+        $quoted = $this->conn->quoteColumnName('name');
+        $this->assertSame('"name"', $quoted);
+        $this->assertFalse($this->conn->isActive());
+
+        // First query triggers connection
+        $this->conn->execute(
+            'CREATE TABLE lazy_int (id INTEGER PRIMARY KEY, name TEXT)'
+        );
+        $this->assertTrue($this->conn->isActive());
+
+        $this->conn->insert("INSERT INTO lazy_int (name) VALUES ('Alice')");
+
+        $result = $this->conn->selectValue(
+            'SELECT name FROM lazy_int WHERE id = 1'
+        );
+        $this->assertEquals('Alice', $result);
+    }
+
+    /**
+     * Transaction round-trip: begin (first connect), insert, commit, select.
+     */
+    public function testTransactionRoundTrip(): void
+    {
+        $this->assertFalse($this->conn->isActive());
+
+        // beginDbTransaction triggers the first connection
+        $this->conn->beginDbTransaction();
+        $this->assertTrue($this->conn->isActive());
+
+        $this->conn->execute(
+            'CREATE TABLE lazy_txn (id INTEGER PRIMARY KEY, name TEXT)'
+        );
+        $this->conn->execute("INSERT INTO lazy_txn (name) VALUES ('Bob')");
+        $this->conn->commitDbTransaction();
+
+        $count = $this->conn->selectValue('SELECT COUNT(*) FROM lazy_txn');
+        $this->assertEquals(1, $count);
+    }
+
+    /**
+     * quoteString triggers lazy connect and produces correct escaping.
+     */
+    public function testQuoteStringAfterLazyConnect(): void
+    {
+        $this->assertFalse($this->conn->isActive());
+
+        $quoted = $this->conn->quoteString("O'Reilly");
+        $this->assertTrue($this->conn->isActive());
+        $this->assertStringContainsString("O''Reilly", $quoted);
+    }
+}

--- a/test/Integration/Sqlite/Psr4AdapterTest.php
+++ b/test/Integration/Sqlite/Psr4AdapterTest.php
@@ -39,6 +39,9 @@ class Psr4AdapterTest extends DatabaseTestCase
 
     public function testConnection()
     {
+        // Lazy connect: not active until first query
+        $this->assertFalse($this->conn->isActive());
+        $this->conn->selectValue('SELECT 1');
         $this->assertTrue($this->conn->isActive());
     }
 

--- a/test/Unit/Adapter/LazyConnectTest.php
+++ b/test/Unit/Adapter/LazyConnectTest.php
@@ -1,0 +1,359 @@
+<?php
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @category Horde
+ * @package  Db
+ * @license  http://www.horde.org/licenses/bsd
+ */
+
+declare(strict_types=1);
+
+namespace Horde\Db\Test\Unit\Adapter;
+
+use Horde\Db\Adapter\Base;
+use Horde\Db\Adapter\Pdo\Sqlite;
+use Horde\Db\Value\Binary;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for lazy database connection behaviour.
+ *
+ * Uses a real Pdo\Sqlite adapter with :memory: to verify that construction
+ * does NOT open a connection, that introspection and schema quoting work
+ * without a live handle, and that the first real query triggers connection.
+ *
+ * We verify lazy behaviour via isActive() rather than a subclass counter,
+ * because Pdo\Sqlite uses catchSchemaChanges() with call_user_func_array
+ * and parent:: resolution, which does not support subclass overrides of
+ * the methods it delegates to.
+ *
+ * @category Horde
+ * @package  Db
+ * @license  http://www.horde.org/licenses/bsd
+ */
+#[CoversClass(Base::class)]
+#[CoversClass(Sqlite::class)]
+class LazyConnectTest extends TestCase
+{
+    private Sqlite $adapter;
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('PDO SQLite extension not available');
+        }
+
+        $this->adapter = new Sqlite([
+            'adapter' => 'pdo_sqlite',
+            'database' => ':memory:',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->adapter) && $this->adapter->isActive()) {
+            $this->adapter->disconnect();
+        }
+    }
+
+    /**
+     * Assert the adapter has not connected yet.
+     */
+    private function assertNotConnected(): void
+    {
+        $this->assertFalse($this->adapter->isActive(), 'Adapter should not be connected');
+        $this->assertNull($this->adapter->rawConnection(), 'Raw connection should be null');
+    }
+
+    /**
+     * Assert the adapter is now connected.
+     */
+    private function assertConnected(): void
+    {
+        $this->assertTrue($this->adapter->isActive(), 'Adapter should be connected');
+        $this->assertNotNull($this->adapter->rawConnection(), 'Raw connection should not be null');
+    }
+
+    // ---------------------------------------------------------------
+    // Group 1: Construction does NOT connect
+    // ---------------------------------------------------------------
+
+    public function testConstructorDoesNotConnect(): void
+    {
+        $this->assertNotConnected();
+    }
+
+    public function testIsActiveReturnsFalseBeforeFirstQuery(): void
+    {
+        $this->assertFalse($this->adapter->isActive());
+    }
+
+    public function testRawConnectionReturnsNullBeforeFirstQuery(): void
+    {
+        $this->assertNull($this->adapter->rawConnection());
+    }
+
+    // ---------------------------------------------------------------
+    // Group 2: Introspection before query does NOT connect
+    // ---------------------------------------------------------------
+
+    public function testAdapterNameDoesNotConnect(): void
+    {
+        $name = $this->adapter->adapterName();
+        $this->assertIsString($name);
+        $this->assertNotConnected();
+    }
+
+    public function testSupportsMigrationsDoesNotConnect(): void
+    {
+        $this->adapter->supportsMigrations();
+        $this->assertNotConnected();
+    }
+
+    public function testGetLastQueryDoesNotConnect(): void
+    {
+        // getLastQuery() has :string return type but lastQuery property is null
+        // before any query — may throw TypeError, but must not trigger connect.
+        try {
+            $this->adapter->getLastQuery();
+        } catch (\TypeError $e) {
+            // Expected: lastQuery is null before any query
+        }
+        $this->assertNotConnected();
+    }
+
+    public function testResetRuntimeDoesNotConnect(): void
+    {
+        $this->adapter->resetRuntime();
+        $this->assertNotConnected();
+    }
+
+    public function testTransactionStartedDoesNotConnect(): void
+    {
+        $this->adapter->transactionStarted();
+        $this->assertNotConnected();
+    }
+
+    // ---------------------------------------------------------------
+    // Group 3: Schema quoting does NOT connect
+    // ---------------------------------------------------------------
+
+    public function testQuoteColumnNameDoesNotConnect(): void
+    {
+        $result = $this->adapter->quoteColumnName('foo');
+        $this->assertSame('"foo"', $result);
+        $this->assertNotConnected();
+    }
+
+    public function testQuoteTableNameDoesNotConnect(): void
+    {
+        $result = $this->adapter->quoteTableName('bar');
+        $this->assertSame('"bar"', $result);
+        $this->assertNotConnected();
+    }
+
+    public function testQuoteTrueDoesNotConnect(): void
+    {
+        $result = $this->adapter->quoteTrue();
+        $this->assertIsString($result);
+        $this->assertNotConnected();
+    }
+
+    public function testQuoteFalseDoesNotConnect(): void
+    {
+        $result = $this->adapter->quoteFalse();
+        $this->assertIsString($result);
+        $this->assertNotConnected();
+    }
+
+    public function testAddLimitOffsetDoesNotConnect(): void
+    {
+        $result = $this->adapter->addLimitOffset(
+            'SELECT * FROM t',
+            ['limit' => 10, 'offset' => 5]
+        );
+        $this->assertStringContainsString('LIMIT', $result);
+        $this->assertNotConnected();
+    }
+
+    // ---------------------------------------------------------------
+    // Group 4: Query methods DO trigger connect
+    // ---------------------------------------------------------------
+
+    public function testExecuteTriggersConnect(): void
+    {
+        $this->assertNotConnected();
+        $this->adapter->execute('SELECT 1');
+        $this->assertConnected();
+    }
+
+    public function testSelectAllTriggersConnect(): void
+    {
+        $this->assertNotConnected();
+        $result = $this->adapter->selectAll('SELECT 1 AS val');
+        $this->assertConnected();
+        $this->assertCount(1, $result);
+    }
+
+    public function testSelectOneTriggersConnect(): void
+    {
+        $this->assertNotConnected();
+        $result = $this->adapter->selectOne('SELECT 1 AS val');
+        $this->assertConnected();
+        $this->assertIsArray($result);
+    }
+
+    public function testSelectValueTriggersConnect(): void
+    {
+        $this->assertNotConnected();
+        $result = $this->adapter->selectValue('SELECT 42');
+        $this->assertConnected();
+        $this->assertEquals(42, $result);
+    }
+
+    public function testInsertTriggersConnect(): void
+    {
+        $this->assertNotConnected();
+        $this->adapter->execute(
+            'CREATE TABLE lazy_test (id INTEGER PRIMARY KEY, name TEXT)'
+        );
+        $this->assertConnected();
+
+        $id = $this->adapter->insert(
+            "INSERT INTO lazy_test (name) VALUES ('Alice')"
+        );
+        $this->assertGreaterThanOrEqual(1, $id);
+    }
+
+    public function testBeginTransactionTriggersConnect(): void
+    {
+        $this->assertNotConnected();
+        $this->adapter->beginDbTransaction();
+        $this->assertConnected();
+        $this->adapter->rollbackDbTransaction();
+    }
+
+    // ---------------------------------------------------------------
+    // Group 5: quoteString triggers connect for PDO
+    // ---------------------------------------------------------------
+
+    public function testQuoteStringTriggersConnect(): void
+    {
+        $this->assertNotConnected();
+        $result = $this->adapter->quoteString('hello');
+        $this->assertConnected();
+        $this->assertIsString($result);
+    }
+
+    // ---------------------------------------------------------------
+    // Group 6: Lifecycle edge cases
+    // ---------------------------------------------------------------
+
+    public function testDisconnectThenQueryReconnects(): void
+    {
+        // First connect via query
+        $this->adapter->execute('SELECT 1');
+        $this->assertConnected();
+
+        // Disconnect
+        $this->adapter->disconnect();
+        $this->assertFalse($this->adapter->isActive());
+
+        // Next query auto-reconnects
+        $this->adapter->execute('SELECT 1');
+        $this->assertConnected();
+    }
+
+    public function testSetCacheAndLoggerBeforeFirstQuery(): void
+    {
+        // Cache and logger can be set before connection.
+        // The constructor already sets stubs, so just verify no connect happens.
+        $this->assertNotConnected();
+
+        // Now query — should connect and work fine with stubs
+        $result = $this->adapter->selectValue('SELECT 99');
+        $this->assertEquals(99, $result);
+        $this->assertConnected();
+    }
+
+    public function testMultipleQueriesConnectOnce(): void
+    {
+        $this->adapter->execute('SELECT 1');
+        $this->assertConnected();
+
+        // Subsequent queries don't cause issues
+        $this->adapter->execute('SELECT 2');
+        $result = $this->adapter->selectValue('SELECT 3');
+        $this->assertEquals(3, $result);
+    }
+
+    public function testExplicitConnectThenQuery(): void
+    {
+        $this->adapter->connect();
+        $this->assertConnected();
+
+        // Query works after explicit connect
+        $result = $this->adapter->selectValue('SELECT 1');
+        $this->assertEquals(1, $result);
+    }
+
+    // ---------------------------------------------------------------
+    // Group 7: Prepared statements (blob paths)
+    // ---------------------------------------------------------------
+
+    public function testInsertBlobTriggersConnect(): void
+    {
+        $this->assertNotConnected();
+
+        $this->adapter->execute(
+            'CREATE TABLE blob_test (id INTEGER PRIMARY KEY, name TEXT, data BLOB)'
+        );
+        $this->assertConnected();
+
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, 'binary data');
+        rewind($stream);
+
+        $id = $this->adapter->insertBlob('blob_test', [
+            'name' => 'test',
+            'data' => new Binary($stream),
+        ]);
+
+        fclose($stream);
+
+        $this->assertGreaterThanOrEqual(1, $id);
+    }
+
+    public function testUpdateBlobTriggersConnect(): void
+    {
+        $this->assertNotConnected();
+
+        $this->adapter->execute(
+            'CREATE TABLE blob_upd (id INTEGER PRIMARY KEY, name TEXT, data BLOB)'
+        );
+        $this->adapter->insert(
+            "INSERT INTO blob_upd (name, data) VALUES ('test', 'old')"
+        );
+
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, 'new binary data');
+        rewind($stream);
+
+        $this->adapter->updateBlob('blob_upd', [
+            'data' => new Binary($stream),
+        ], 'id = 1');
+
+        fclose($stream);
+
+        $result = $this->adapter->selectValue(
+            'SELECT name FROM blob_upd WHERE id = 1'
+        );
+        $this->assertEquals('test', $result);
+    }
+}

--- a/test/Unit/Adapter/LazyConnectTest.php
+++ b/test/Unit/Adapter/LazyConnectTest.php
@@ -20,6 +20,7 @@ use Horde\Db\Adapter\Pdo\Sqlite;
 use Horde\Db\Value\Binary;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 /**
  * Tests for lazy database connection behaviour.
@@ -122,7 +123,7 @@ class LazyConnectTest extends TestCase
         // before any query — may throw TypeError, but must not trigger connect.
         try {
             $this->adapter->getLastQuery();
-        } catch (\TypeError $e) {
+        } catch (TypeError $e) {
             // Expected: lastQuery is null before any query
         }
         $this->assertNotConnected();


### PR DESCRIPTION
Setting up an OO Query Builder as a middle ground between ORM and hand written SQL.
Moving initialation of the actual DB connection inside the DB Adapter until as late as possible.

Sometimes the cache has all the answers but for OO reasons we need the DB Adapter. Let's reduce the cost of this.

- **feat: OO Immutable Query Builder**
- **feat: Add Delete/Inser/Update builders**
- **feat: Defer setting charset and other settings until we really need the internal handle**
