### PR TITLE
fix(db): stringify scalar values in PDO blob serialization

### DIFF
--- a/lib/Horde/Db/Adapter/Pdo/Base.php
+++ b/lib/Horde/Db/Adapter/Pdo/Base.php
@@ -332,7 +332,7 @@ abstract class Horde_Db_Adapter_Pdo_Base extends Horde_Db_Adapter_Base
     protected function _lobValueString(Horde_Db_Value $value)
     {
         $data = $value->value;
-        return is_string($data) ? $data : '';
+        return is_string($data) ? $data : (is_scalar($data) ? (string) $data : '');
     }
 
     /**

--- a/src/Adapter/Pdo/Base.php
+++ b/src/Adapter/Pdo/Base.php
@@ -349,7 +349,7 @@ abstract class Base extends BaseAdapter
     protected function lobValueString($value)
     {
         $data = $value->value;
-        return is_string($data) ? $data : '';
+        return is_string($data) ? $data : (is_scalar($data) ? (string) $data : '');
     }
 
     /**

--- a/test/Integration/Pdo/MultiBlobBindingTest.php
+++ b/test/Integration/Pdo/MultiBlobBindingTest.php
@@ -18,6 +18,7 @@ use Horde\Db\Test\Integration\DatabaseTestCase;
 
 /**
  * @covers Horde_Db_Adapter_Pdo_Base::_executePrepared
+ * @covers Horde_Db_Adapter_Pdo_Base::_lobValueString
  */
 class MultiBlobBindingTest extends DatabaseTestCase
 {
@@ -107,5 +108,63 @@ class MultiBlobBindingTest extends DatabaseTestCase
 
         $this->assertSame($folder, $row['sync_data']);
         $this->assertSame($pending, $row['sync_pending']);
+    }
+
+    /**
+     * @dataProvider scalarBinaryPayloadProvider
+     */
+    public function testInsertBlobStoresScalarBinaryPayload($payload, $expected)
+    {
+        $key = '{test}scalar-insert-' . md5((string) $expected);
+
+        $this->conn->insertBlob(
+            'activesync_state',
+            [
+                'sync_key' => $key,
+                'sync_data' => new Horde_Db_Value_Binary($payload),
+                'sync_pending' => '',
+                'sync_mod' => 0,
+            ],
+            'sync_key',
+            $key
+        );
+
+        $stored = $this->conn->selectValue(
+            'SELECT sync_data FROM activesync_state WHERE sync_key = ?',
+            [$key]
+        );
+
+        $this->assertSame($expected, $stored);
+    }
+
+    /**
+     * @dataProvider scalarBinaryPayloadProvider
+     */
+    public function testUpdateBlobRoundTripsScalarBinaryPayload($payload, $expected)
+    {
+        $this->conn->updateBlob(
+            'activesync_state',
+            [
+                'sync_data' => new Horde_Db_Value_Binary($payload),
+            ],
+            ['sync_key = ?', ['{test}1']]
+        );
+
+        $stored = $this->conn->selectValue(
+            'SELECT sync_data FROM activesync_state WHERE sync_key = ?',
+            ['{test}1']
+        );
+
+        $this->assertSame($expected, $stored);
+    }
+
+    public static function scalarBinaryPayloadProvider(): array
+    {
+        return [
+            'integer one' => [1, '1'],
+            'integer zero' => [0, '0'],
+            'string one' => ['1', '1'],
+            'string zero' => ['0', '0'],
+        ];
     }
 }


### PR DESCRIPTION
## Summary

- Fix PDO BLOB serialization so scalar values (integers, floats, booleans) are stored correctly instead of empty binary data
- Apply the same change in both autoload trees: legacy `lib/` (PSR-0) and modern `src/` (PSR-4)
- Complements `horde/prefs` SQL storage fix; protects all callers of `insertBlob()` / `updateBlob()`, not only preferences

## Problem

`Horde_Db_Adapter_Pdo_Base` and `Horde\Db\Adapter\Pdo\Base` extract LOB payload via `_lobValueString()` / `lobValueString()`:

```php
return is_string($data) ? $data : '';
```

Non-string scalars (e.g. integer `1` from checkbox preferences) are treated as invalid and serialized as an **empty string**. The database write succeeds, but the stored blob is empty.

This affected `horde_prefs` when integer values reached the DB layer without prior string coercion—for example IMP `use_trash` appeared saved in the UI but reloaded as disabled.

## Solution

Stringify scalar LOB values before binding:

```php
return is_string($data) ? $data : (is_scalar($data) ? (string) $data : '');
```

### Changed files

| Tree | File | Method |
|------|------|--------|
| `lib/` (PSR-0) | `lib/Horde/Db/Adapter/Pdo/Base.php` | `_lobValueString()` |
| `src/` (PSR-4) | `src/Adapter/Pdo/Base.php` | `lobValueString()` |

Both copies must stay in sync: `horde/db` autoloads `Horde_Db_*` from `lib/` today and `Horde\Db\*` from `src/` for the ongoing namespace migration.

## Related change

- `horde/prefs`: `lib/Horde/Prefs/Storage/Sql.php` also casts preference values with `strval()` before wrapping them in `Horde_Db_Value_Binary` (defense in depth at the prefs layer)

## Test plan

- [ ] Store integer `1` via `Horde_Db_Value_Binary` + `updateBlob()` on PostgreSQL; confirm `pref_value` / blob column is not empty
- [ ] Store integer `0` and string `'1'` / `'0'`; confirm round-trip matches input
- [ ] Save IMP checkbox preference `use_trash` and verify persistence without the prefs-only workaround
- [ ] Run existing `horde/db` unit/integration tests if available
- [ ] Smoke-test other BLOB writes (e.g. binary attachment metadata) to ensure no regression for stream/resource LOB values
