### PR TITLE
fix(postgresql): guard null column defaults in extractValueFromDefault

### DIFF
--- a/lib/Horde/Db/Adapter/Postgresql/Column.php
+++ b/lib/Horde/Db/Adapter/Postgresql/Column.php
@@ -123,6 +123,10 @@ class Horde_Db_Adapter_Postgresql_Column extends Horde_Db_Adapter_Base_Column
      */
     protected function _extractValueFromDefault($default)
     {
+        if ($default === null) {
+            return null;
+        }
+
         switch (true) {
             case preg_match('/\A-?\d+(\.\d*)?\z/', $default):
                 // Numeric types

--- a/src/Adapter/Postgresql/Column.php
+++ b/src/Adapter/Postgresql/Column.php
@@ -133,6 +133,10 @@ class Column extends BaseColumn
      */
     protected function extractValueFromDefault($default)
     {
+        if ($default === null) {
+            return null;
+        }
+
         switch (true) {
             case preg_match('/\A-?\d+(\.\d*)?\z/', $default):
                 // Numeric types

--- a/src/Adapter/Postgresql/Column.php
+++ b/src/Adapter/Postgresql/Column.php
@@ -127,7 +127,7 @@ class Column extends BaseColumn
     /**
      * Extracts the value from a PostgreSQL column default definition.
      *
-     * @param string $default  The default value expression.
+     * @param string|null $default  The default value expression.
      *
      * @return mixed  Extracted default value (string, int, float, bool, or null).
      */

--- a/test/Legacy/Adapter/Postgresql/ColumnLegacyTest.php
+++ b/test/Legacy/Adapter/Postgresql/ColumnLegacyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Copyright 2007-2026 Maintainable Software, LLC
+ * Copyright 2008-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @category Horde
+ * @package  Db
+ * @license  http://www.horde.org/licenses/bsd
+ */
+
+declare(strict_types=1);
+
+namespace Horde\Db\Test\Adapter\Postgresql;
+
+use Horde_Db_Adapter_Postgresql_Column;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the legacy Horde_Db_Adapter_Postgresql_Column class from lib/.
+ *
+ * @category Horde
+ * @package  Db
+ * @license  http://www.horde.org/licenses/bsd
+ */
+#[CoversClass(Horde_Db_Adapter_Postgresql_Column::class)]
+class ColumnLegacyTest extends TestCase
+{
+    /**
+     * Test that constructing with a null default does not trigger errors
+     * and returns null from getDefault().
+     *
+     * Regression test: passing null to _extractValueFromDefault() must not
+     * call preg_match() with a null subject (deprecated in PHP 8.4).
+     */
+    public function testMissingDefaultNull(): void
+    {
+        $col = new Horde_Db_Adapter_Postgresql_Column('name', null, 'integer');
+        $this->assertNull($col->getDefault());
+    }
+}

--- a/test/Legacy/Adapter/Postgresql/ColumnTest.php
+++ b/test/Legacy/Adapter/Postgresql/ColumnTest.php
@@ -149,4 +149,10 @@ class ColumnTest extends ColumnBase
         $col = new Column('name', '', 'character varying(255)');
         $this->assertEquals('', $col->getDefault());
     }
+
+    public function testMissingDefaultNull()
+    {
+        $col = new Column('name', null, 'integer');
+        $this->assertNull($col->getDefault());
+    }
 }


### PR DESCRIPTION
## Summary
- Return early when PostgreSQL column default expressions are `null`, before the `preg_match()` chain in `extractValueFromDefault()`.
- Apply the same guard in both the legacy (`lib/`) and PSR-4 (`src/`) PostgreSQL Column classes.
- Add a unit test covering columns without a default expression.

## Motivation
Schema introspection via `pg_get_expr()` can leave `column_default` unset for columns with no default. On PHP 8.4, passing that value to `preg_match()` emits deprecation warnings. This shows up during schema-heavy requests (for example ActiveSync Tasks sync triggering Nag table introspection).

## Changes
- `lib/Horde/Db/Adapter/Postgresql/Column.php` — `_extractValueFromDefault()`
- `src/Adapter/Postgresql/Column.php` — `extractValueFromDefault()`
- `test/Legacy/Adapter/Postgresql/ColumnTest.php` — `testMissingDefaultNull()`

## Test plan
- [x] `vendor/bin/phpunit -c phpunit.xml.dist --testsuite legacy --filter ColumnTest` (PostgreSQL Column tests)
- [x] Construct `Column` with `null` default under PHP 8.4 with `E_ALL`; no deprecation warnings
